### PR TITLE
Setup GitHub Pages CI

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,52 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Publish project
+        env:
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+        run: |
+          dotnet publish RosaryBlazor.csproj -c Release -o publish \
+            -p:StaticWebAssetBasePath="/$REPOSITORY_NAME"
+          touch publish/wwwroot/.nojekyll
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./publish/wwwroot
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+


### PR DESCRIPTION
## Summary
- add workflow to build the project
- publish the output to GitHub Pages using `actions/deploy-pages`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ed64c73848322b38f21b2b01fadc7