### PR TITLE
Fix GitHub Pages artifact path

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3  # upgrade from @v2 → @v3 per deprecation notice:contentReference[oaicite:2]{index=2}
         with:
-          path: ./publish/wwwroot/RosaryBlazor
+          path: ./publish/wwwroot
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- correct path to publish artifacts for GitHub Pages deployment

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ef778d8d48322b843b2a5d451d05d